### PR TITLE
add an option to ignore amazon point lines for lbbamazon plugin

### DIFF
--- a/src/ofxstatement/plugins/lbbamazon.py
+++ b/src/ofxstatement/plugins/lbbamazon.py
@@ -17,7 +17,8 @@ class LbbAmazonCsvStatementParser(CsvStatementParser):
 
         # Empty transactions to include amazon points
         if line[6] == '':
-            return None # ignore amazon points
+            if self.ignore_amazon_points:
+                return None 
             line[6] = '0,00'
         #Change decimalsign from , to .
         line[6] = line[6].replace(',', '.')
@@ -35,4 +36,5 @@ class LbbAmazonPlugin(Plugin):
         parser.statement.account_id = self.settings['account']
         parser.statement.currency = self.settings['currency']
         parser.statement.bank_id = self.settings.get('bank', 'LBB_Amazon')
+        parser.ignore_amazon_points = self.settings.get('ignore_amazon_points', 'false').lower() in ('true', 'yes', 'on')
         return parser


### PR DESCRIPTION
I added an option 'ignore_amazon_points' which can be used to ignore lines with amazon points instead of setting the value of this lines to 0.

This makes it easier to import the resulting fox file in programs like ynab
