### PR TITLE
add option to handle Amazon exchange fee lines (AUSLANDSEINSATZENTGELT) by merging them into the real transaction

### DIFF
--- a/src/ofxstatement/plugins/lbbamazon.py
+++ b/src/ofxstatement/plugins/lbbamazon.py
@@ -32,6 +32,8 @@ class LbbAmazonCsvStatementParser(CsvStatementParser):
                     # delete the exchange fee transaction
                     del statement.lines[idx]
                 # please note that idx may now point to the next fresh line
+                if idx >= len(statement.lines):
+                    break
                 if statement.lines[idx].amount:
                     last_real_transaction_id = idx
         return statement


### PR DESCRIPTION
exhange fee (AUSLANDSEINSATZENTGELT) generate seperate transactions
in the amaazonlbb csv files.

when adding the option

```
merge_exchange_fee = yes
```

we try to merge the exchange fee lines to the coresponding statement
line and remove the seperate exchange fee line.
